### PR TITLE
Remove linux 32 bit support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,7 @@ set -e
 # This script downloads the binaries for the most recent version of TabNine.
 
 version="$(curl -sS https://update.tabnine.com/bundles/version)"
-targets='i686-unknown-linux-musl
-    x86_64-apple-darwin
+targets='x86_64-apple-darwin
     aarch64-apple-darwin
     x86_64-unknown-linux-musl'
 


### PR DESCRIPTION
We can't get the zip file for Linux 32bit now (https://update.tabnine.com/bundles/4.0.60/i686-unknown-linux-musl/TabNine/TabNine.zip is forbidden). This patch drops the support.

I wrote this patch using https://github.com/codota/TabNine/commit/6e83bb75e692ec1d185a3bdcb3b5df42a14a700b as a reference. 